### PR TITLE
Validate sidecar dock width minimum

### DIFF
--- a/hypr-smartd/README.md
+++ b/hypr-smartd/README.md
@@ -35,7 +35,7 @@ modes:
             params:
               workspace: 3
               side: right
-              widthPercent: 25
+              widthPercent: 25 # must be between 10 and 50
               match:
                 anyClass: [Slack, discord]
   - name: Gaming
@@ -49,7 +49,7 @@ modes:
               target: active
 ```
 
-Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the provided systemd unit. Send `SIGHUP` (e.g. `systemctl --user reload hypr-smartd`) to reload without restarting.
+Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the provided systemd unit. `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. Send `SIGHUP` (e.g. `systemctl --user reload hypr-smartd`) to reload without restarting.
 
 ## Makefile targets
 

--- a/hypr-smartd/configs/example.yaml
+++ b/hypr-smartd/configs/example.yaml
@@ -12,7 +12,7 @@ modes:
             params:
               workspace: 3
               side: right
-              widthPercent: 25
+              widthPercent: 25 # allowed range: 10-50
               match:
                 anyClass: [Slack, discord]
   - name: Gaming

--- a/hypr-smartd/internal/layout/geom.go
+++ b/hypr-smartd/internal/layout/geom.go
@@ -12,11 +12,19 @@ type Rect struct {
 
 // SplitSidecar returns the primary and sidecar rectangles given a monitor rect and desired width percentage.
 func SplitSidecar(monitor Rect, side string, widthPercent float64) (main Rect, dock Rect) {
+	const (
+		defaultWidth = 25
+		minWidth     = 10
+		maxWidth     = 50
+	)
 	if widthPercent <= 0 {
-		widthPercent = 25
+		widthPercent = defaultWidth
 	}
-	if widthPercent > 50 {
-		widthPercent = 50
+	if widthPercent < minWidth {
+		widthPercent = minWidth
+	}
+	if widthPercent > maxWidth {
+		widthPercent = maxWidth
 	}
 	dockWidth := monitor.Width * widthPercent / 100
 	main = monitor

--- a/hypr-smartd/internal/layout/geom_test.go
+++ b/hypr-smartd/internal/layout/geom_test.go
@@ -12,3 +12,17 @@ func TestSplitSidecarLeft(t *testing.T) {
 		t.Fatalf("expected dock X to remain 0")
 	}
 }
+
+func TestSplitSidecarClampsMinimumWidth(t *testing.T) {
+	monitor := Rect{X: 0, Y: 0, Width: 1000, Height: 800}
+	main, dock := SplitSidecar(monitor, "right", 5)
+	if dock.Width != 100 {
+		t.Fatalf("expected dock width to clamp to 100, got %v", dock.Width)
+	}
+	if main.Width != 900 {
+		t.Fatalf("expected main width to shrink to 900, got %v", main.Width)
+	}
+	if dock.X != 900 {
+		t.Fatalf("expected dock X to start at 900, got %v", dock.X)
+	}
+}

--- a/hypr-smartd/internal/rules/actions.go
+++ b/hypr-smartd/internal/rules/actions.go
@@ -80,6 +80,9 @@ func buildSidecarDock(params map[string]interface{}) (Action, error) {
 	if err != nil {
 		return nil, err
 	}
+	if width < 10 {
+		return nil, fmt.Errorf("widthPercent must be at least 10, got %v", width)
+	}
 	matcher, err := parseClientMatcher(params["match"])
 	if err != nil {
 		return nil, err

--- a/hypr-smartd/internal/rules/actions_test.go
+++ b/hypr-smartd/internal/rules/actions_test.go
@@ -1,0 +1,13 @@
+package rules
+
+import "testing"
+
+func TestBuildSidecarDockRejectsNarrowWidth(t *testing.T) {
+	_, err := buildSidecarDock(map[string]interface{}{
+		"workspace":    1,
+		"widthPercent": 5,
+	})
+	if err == nil {
+		t.Fatalf("expected error for widthPercent below minimum")
+	}
+}


### PR DESCRIPTION
## Summary
- enforce the 10% minimum width for layout.sidecarDock during action construction
- clamp SplitSidecar geometry calculations to respect the 10% minimum and add coverage for it
- document the supported width range in the README and example configuration

## Acceptance Criteria
- [x] Values below 10% in layout.sidecarDock are rejected during config compilation
- [x] SplitSidecar respects the minimum width when laying out the dock
- [x] Tests cover the minimum width behavior and documentation reflects the requirement

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e0802db6348325b51953ab55136b92