### PR TITLE
Log debounce skip events in engine

### DIFF
--- a/hypr-smartd/internal/engine/engine_test.go
+++ b/hypr-smartd/internal/engine/engine_test.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hyprpal/hypr-smartd/internal/layout"
+	"github.com/hyprpal/hypr-smartd/internal/rules"
+	"github.com/hyprpal/hypr-smartd/internal/state"
+	"github.com/hyprpal/hypr-smartd/internal/util"
+)
+
+type fakeHyprctl struct {
+	clients         []state.Client
+	workspaces      []state.Workspace
+	monitors        []state.Monitor
+	activeWorkspace int
+	activeClient    string
+	dispatched      [][]string
+}
+
+func (f *fakeHyprctl) ListClients(context.Context) ([]state.Client, error) {
+	return append([]state.Client(nil), f.clients...), nil
+}
+
+func (f *fakeHyprctl) ListWorkspaces(context.Context) ([]state.Workspace, error) {
+	return append([]state.Workspace(nil), f.workspaces...), nil
+}
+
+func (f *fakeHyprctl) ListMonitors(context.Context) ([]state.Monitor, error) {
+	return append([]state.Monitor(nil), f.monitors...), nil
+}
+
+func (f *fakeHyprctl) ActiveWorkspaceID(context.Context) (int, error) {
+	return f.activeWorkspace, nil
+}
+
+func (f *fakeHyprctl) ActiveClientAddress(context.Context) (string, error) {
+	return f.activeClient, nil
+}
+
+func (f *fakeHyprctl) Dispatch(args ...string) error {
+	copyArgs := append([]string(nil), args...)
+	f.dispatched = append(f.dispatched, copyArgs)
+	return nil
+}
+
+func TestReconcileAndApplyLogsDebounceSkip(t *testing.T) {
+	hypr := &fakeHyprctl{
+		workspaces: []state.Workspace{{ID: 1, Name: "1", MonitorName: "HDMI-A-1"}},
+		monitors:   []state.Monitor{{ID: 1, Name: "HDMI-A-1", Rectangle: layout.Rect{Width: 1920, Height: 1080}}},
+	}
+	var logs bytes.Buffer
+	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
+	mode := rules.Mode{
+		Name: "Focus",
+		Rules: []rules.Rule{{
+			Name:     "noop",
+			When:     func(rules.EvalContext) bool { return true },
+			Actions:  []rules.Action{rules.NoopAction{}},
+			Debounce: time.Second,
+		}},
+	}
+	eng := New(hypr, logger, []rules.Mode{mode}, false)
+	key := mode.Name + ":" + mode.Rules[0].Name
+	eng.debounce[key] = time.Now()
+
+	if err := eng.reconcileAndApply(context.Background()); err != nil {
+		t.Fatalf("reconcileAndApply returned error: %v", err)
+	}
+	got := logs.String()
+	expected := "rule noop skipped (debounced) [mode Focus]"
+	if !strings.Contains(got, expected) {
+		t.Fatalf("expected log %q, got %q", expected, got)
+	}
+	if len(hypr.dispatched) != 0 {
+		t.Fatalf("expected no dispatches, got %d", len(hypr.dispatched))
+	}
+}


### PR DESCRIPTION
## Summary
- log when rules are skipped due to debounce, including the active mode context
- relax the engine client dependency to support testing and add a focused unit test

## Checklist
- [x] Debounce skip path emits the expected log message
- [x] Engine planner has test coverage for debounce logging

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e08f1459dc8325894e513378b0abad