### PR TITLE
feat: watch config file for automatic reloads

### DIFF
--- a/hypr-smartd/README.md
+++ b/hypr-smartd/README.md
@@ -53,7 +53,7 @@ modes:
               target: active
 ```
 
-Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the provided systemd unit. `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. Send `SIGHUP` (e.g. `systemctl --user reload hypr-smartd`) to reload without restarting.
+Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the provided systemd unit. `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hypr-smartd`) for manual reloads.
 
 ## Makefile targets
 

--- a/hypr-smartd/go.mod
+++ b/hypr-smartd/go.mod
@@ -2,4 +2,9 @@ module github.com/hyprpal/hypr-smartd
 
 go 1.22
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/fsnotify/fsnotify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require golang.org/x/sys v0.13.0 // indirect

--- a/hypr-smartd/go.sum
+++ b/hypr-smartd/go.sum
@@ -1,3 +1,7 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary
- add an fsnotify watcher so the daemon reloads the active config when the file changes
- reuse the existing reload logic for both SIGHUP and file change events while logging unexpected watcher errors
- document the new automatic reload behaviour in the README

## Acceptance Criteria
- [x] Config changes trigger a reload without restarting the daemon
- [x] Manual `SIGHUP` reload path continues to work alongside automatic reloads

## Testing
- [x] `go test ./...`

## How to test
1. Run `hypr-smartd` with a valid configuration file.
2. Modify and save the watched config file; observe logs reporting an automatic reload.
3. Send `SIGHUP` to the process and confirm it reloads the config without exiting.


------
https://chatgpt.com/codex/tasks/task_e_68e11ae587c08325bb4fc6085de22303