### PR TITLE
Rename module and binary to hyprpal

### DIFF
--- a/hypr-smartd/LICENSE
+++ b/hypr-smartd/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 hypr-smartd contributors
+Copyright (c) 2024 hyprpal contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/hypr-smartd/Makefile
+++ b/hypr-smartd/Makefile
@@ -1,22 +1,22 @@
-BINARY=bin/hypr-smartd
+BINARY=bin/hyprpal
 INSTALL_DIR?=$(HOME)/.local/bin
 
 .PHONY: build run install service lint test
 
 build:
-	mkdir -p bin
-	go build -o $(BINARY) ./cmd/hypr-smartd
+        mkdir -p bin
+        go build -o $(BINARY) ./cmd/hyprpal
 
 run:
-	go run ./cmd/hypr-smartd --config configs/example.yaml
+        go run ./cmd/hyprpal --config configs/example.yaml
 
 install:
-	mkdir -p $(INSTALL_DIR)
-	GOBIN=$(INSTALL_DIR) go install ./cmd/hypr-smartd
+        mkdir -p $(INSTALL_DIR)
+        GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal
 
 service:
-	systemctl --user daemon-reload
-	systemctl --user enable --now hypr-smartd.service
+        systemctl --user daemon-reload
+        systemctl --user enable --now hyprpal.service
 
 lint:
 	go vet ./...

--- a/hypr-smartd/README.md
+++ b/hypr-smartd/README.md
@@ -1,6 +1,6 @@
-# hypr-smartd
+# hyprpal
 
-`hypr-smartd` is a small companion daemon for [Hyprland](https://hyprland.org/) that listens to compositor events, maintains a live world snapshot of monitors/workspaces/clients, and applies declarative layout rules. v0.1 ships with sidecar docking and fullscreen enforcement actions so you can keep communication apps docked while focusing on your main workspace or go distraction-free in Gaming mode.
+`hyprpal` is a small companion daemon for [Hyprland](https://hyprland.org/) that listens to compositor events, maintains a live world snapshot of monitors/workspaces/clients, and applies declarative layout rules. v0.1 ships with sidecar docking and fullscreen enforcement actions so you can keep communication apps docked while focusing on your main workspace or go distraction-free in Gaming mode.
 
 ## Quick Start
 
@@ -9,7 +9,7 @@
    ```bash
    make build
    ```
-3. Copy `configs/example.yaml` to `~/.config/hypr-smartd/config.yaml` and edit it for your workspace/app names.
+3. Copy `configs/example.yaml` to `~/.config/hyprpal/config.yaml` and edit it for your workspace/app names.
 4. Run the daemon from your session:
    ```bash
    make run
@@ -17,7 +17,7 @@
    Use `--dry-run` to preview dispatches without affecting windows.
 5. Follow logs while iterating:
    ```bash
-   journalctl --user -fu hypr-smartd
+   journalctl --user -fu hyprpal
    ```
 
 ## Configuration
@@ -53,11 +53,11 @@ modes:
               target: active
 ```
 
-Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the provided systemd unit. `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hypr-smartd`) for manual reloads.
+Place the configuration at `~/.config/hyprpal/config.yaml` to align with the provided systemd unit. `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hyprpal`) for manual reloads.
 
 ## Makefile targets
 
-- `make build` – compile to `bin/hypr-smartd`.
+- `make build` – compile to `bin/hyprpal`.
 - `make run` – run the daemon against `configs/example.yaml`.
 - `make install` – install the binary to `~/.local/bin` (override with `INSTALL_DIR=...`).
 - `make service` – reload and start the user service.
@@ -66,20 +66,20 @@ Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the
 
 ## Systemd (user) service
 
-Install the binary with `make install` (which places it at `~/.local/bin/hypr-smartd` by default), copy `system/hypr-smartd.service` to `~/.config/systemd/user/`, then enable it:
+Install the binary with `make install` (which places it at `~/.local/bin/hyprpal` by default), copy `system/hyprpal.service` to `~/.config/systemd/user/`, then enable it:
 
 ```bash
 mkdir -p ~/.config/systemd/user/
-cp system/hypr-smartd.service ~/.config/systemd/user/
+cp system/hyprpal.service ~/.config/systemd/user/
 systemctl --user daemon-reload
-systemctl --user enable --now hypr-smartd.service
-journalctl --user -fu hypr-smartd
+systemctl --user enable --now hyprpal.service
+journalctl --user -fu hyprpal
 ```
 
 ## Acceptance smoke test
 
 1. Start Hyprland and open Slack/Discord plus your editor on workspace 3.
-2. Run `hypr-smartd --mode Coding`.
+2. Run `hyprpal --mode Coding`.
 3. Observe a log similar to:
    ```
    [INFO] DRY-RUN dispatch: [setfloatingaddress address:0xabc 1]
@@ -87,7 +87,7 @@ journalctl --user -fu hypr-smartd
    [INFO] DRY-RUN dispatch: [resizewindowpixel exact 480 1440]
    ```
 4. Re-run without `--dry-run` to apply the sidecar.
-5. Switch to Gaming mode (`hypr-smartd --mode Gaming`) and launch a game window; it will be forced fullscreen.
+5. Switch to Gaming mode (`hyprpal --mode Gaming`) and launch a game window; it will be forced fullscreen.
 
 ## Roadmap (v0.1 → v0.2)
 

--- a/hypr-smartd/cmd/hyprpal/main.go
+++ b/hypr-smartd/cmd/hyprpal/main.go
@@ -11,16 +11,16 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/hyprpal/hypr-smartd/internal/config"
-	"github.com/hyprpal/hypr-smartd/internal/engine"
-	"github.com/hyprpal/hypr-smartd/internal/ipc"
-	"github.com/hyprpal/hypr-smartd/internal/rules"
-	"github.com/hyprpal/hypr-smartd/internal/util"
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/engine"
+	"github.com/hyprpal/hyprpal/internal/ipc"
+	"github.com/hyprpal/hyprpal/internal/rules"
+	"github.com/hyprpal/hyprpal/internal/util"
 )
 
 func main() {
 	home, _ := os.UserHomeDir()
-	defaultConfig := filepath.Join(home, ".config", "hypr-smartd", "config.yaml")
+	defaultConfig := filepath.Join(home, ".config", "hyprpal", "config.yaml")
 
 	cfgPath := flag.String("config", defaultConfig, "path to YAML config")
 	dryRun := flag.Bool("dry-run", false, "do not dispatch commands")

--- a/hypr-smartd/go.mod
+++ b/hypr-smartd/go.mod
@@ -1,4 +1,4 @@
-module github.com/hyprpal/hypr-smartd
+module github.com/hyprpal/hyprpal
 
 go 1.22
 

--- a/hypr-smartd/internal/engine/engine.go
+++ b/hypr-smartd/internal/engine/engine.go
@@ -6,11 +6,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyprpal/hypr-smartd/internal/ipc"
-	"github.com/hyprpal/hypr-smartd/internal/layout"
-	"github.com/hyprpal/hypr-smartd/internal/rules"
-	"github.com/hyprpal/hypr-smartd/internal/state"
-	"github.com/hyprpal/hypr-smartd/internal/util"
+	"github.com/hyprpal/hyprpal/internal/ipc"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/rules"
+	"github.com/hyprpal/hyprpal/internal/state"
+	"github.com/hyprpal/hyprpal/internal/util"
 )
 
 type hyprctlClient interface {

--- a/hypr-smartd/internal/engine/engine_test.go
+++ b/hypr-smartd/internal/engine/engine_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyprpal/hypr-smartd/internal/layout"
-	"github.com/hyprpal/hypr-smartd/internal/rules"
-	"github.com/hyprpal/hypr-smartd/internal/state"
-	"github.com/hyprpal/hypr-smartd/internal/util"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/rules"
+	"github.com/hyprpal/hyprpal/internal/state"
+	"github.com/hyprpal/hyprpal/internal/util"
 )
 
 type fakeHyprctl struct {

--- a/hypr-smartd/internal/ipc/events.go
+++ b/hypr-smartd/internal/ipc/events.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hyprpal/hypr-smartd/internal/util"
+	"github.com/hyprpal/hyprpal/internal/util"
 )
 
 // Event represents a Hyprland event stream payload.

--- a/hypr-smartd/internal/ipc/hyprctl.go
+++ b/hypr-smartd/internal/ipc/hyprctl.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/hyprpal/hypr-smartd/internal/layout"
-	"github.com/hyprpal/hypr-smartd/internal/state"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/state"
 )
 
 // Client wraps hyprctl shell-outs.

--- a/hypr-smartd/internal/rules/actions.go
+++ b/hypr-smartd/internal/rules/actions.go
@@ -5,10 +5,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hyprpal/hypr-smartd/internal/config"
-	"github.com/hyprpal/hypr-smartd/internal/layout"
-	"github.com/hyprpal/hypr-smartd/internal/state"
-	"github.com/hyprpal/hypr-smartd/internal/util"
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/state"
+	"github.com/hyprpal/hyprpal/internal/util"
 )
 
 // ActionContext is passed to action planners.

--- a/hypr-smartd/internal/rules/actions_test.go
+++ b/hypr-smartd/internal/rules/actions_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hyprpal/hypr-smartd/internal/layout"
-	"github.com/hyprpal/hypr-smartd/internal/state"
-	"github.com/hyprpal/hypr-smartd/internal/util"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/state"
+	"github.com/hyprpal/hyprpal/internal/util"
 )
 
 func TestBuildSidecarDockRejectsNarrowWidth(t *testing.T) {

--- a/hypr-smartd/internal/rules/match.go
+++ b/hypr-smartd/internal/rules/match.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hyprpal/hypr-smartd/internal/config"
-	"github.com/hyprpal/hypr-smartd/internal/state"
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/state"
 )
 
 // EvalContext contains world snapshot and currently selected mode.

--- a/hypr-smartd/internal/rules/match_test.go
+++ b/hypr-smartd/internal/rules/match_test.go
@@ -3,8 +3,8 @@ package rules
 import (
 	"testing"
 
-	"github.com/hyprpal/hypr-smartd/internal/config"
-	"github.com/hyprpal/hypr-smartd/internal/state"
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/state"
 )
 
 func worldFixture(t *testing.T, activeIndex int, clients ...state.Client) *state.World {

--- a/hypr-smartd/internal/rules/rules.go
+++ b/hypr-smartd/internal/rules/rules.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hyprpal/hypr-smartd/internal/config"
+	"github.com/hyprpal/hyprpal/internal/config"
 )
 
 // Rule represents a compiled rule ready for evaluation.

--- a/hypr-smartd/internal/state/world.go
+++ b/hypr-smartd/internal/state/world.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/hyprpal/hypr-smartd/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/layout"
 )
 
 // Client describes a Hyprland client window.

--- a/hypr-smartd/system/hyprpal.service
+++ b/hypr-smartd/system/hyprpal.service
@@ -1,10 +1,10 @@
 [Unit]
-Description=hypr-smartd layout daemon
+Description=hyprpal layout daemon
 After=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/hypr-smartd --config %h/.config/hypr-smartd/config.yaml
+ExecStart=%h/.local/bin/hyprpal --config %h/.config/hyprpal/config.yaml
 Restart=on-failure
 RestartSec=2
 


### PR DESCRIPTION
## Summary
- rename the Go module and internal imports to `github.com/hyprpal/hyprpal`
- rename the CLI entrypoint, binary outputs, and documentation defaults to `hyprpal`
- update the systemd unit and Makefile targets to build and install the `hyprpal` service

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e11f66867083259d3510d7c4b0a11e