### PR TITLE
Add hsctl control CLI and client

### DIFF
--- a/hypr-smartd/Makefile
+++ b/hypr-smartd/Makefile
@@ -1,22 +1,25 @@
-BINARY=bin/hyprpal
+BIN_DIR=bin
+HYPRPAL_BIN=$(BIN_DIR)/hyprpal
+HSCTL_BIN=$(BIN_DIR)/hsctl
 INSTALL_DIR?=$(HOME)/.local/bin
 
 .PHONY: build run install service lint test
 
 build:
-        mkdir -p bin
-        go build -o $(BINARY) ./cmd/hyprpal
+	mkdir -p $(BIN_DIR)
+	go build -o $(HYPRPAL_BIN) ./cmd/hyprpal
+	go build -o $(HSCTL_BIN) ./cmd/hsctl
 
 run:
-        go run ./cmd/hyprpal --config configs/example.yaml
+	go run ./cmd/hyprpal --config configs/example.yaml
 
 install:
-        mkdir -p $(INSTALL_DIR)
-        GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal
+	mkdir -p $(INSTALL_DIR)
+	GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal ./cmd/hsctl
 
 service:
-        systemctl --user daemon-reload
-        systemctl --user enable --now hyprpal.service
+	systemctl --user daemon-reload
+	systemctl --user enable --now hyprpal.service
 
 lint:
 	go vet ./...

--- a/hypr-smartd/cmd/hsctl/main.go
+++ b/hypr-smartd/cmd/hsctl/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hyprpal/hyprpal/internal/control/client"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(argv []string) error {
+	fs := flag.NewFlagSet("hsctl", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	socket := fs.String("socket", "", "path to hyprpal control socket")
+	timeout := fs.Duration("timeout", 3*time.Second, "control request timeout")
+	if err := fs.Parse(argv); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	args := fs.Args()
+	if len(args) == 0 {
+		fs.Usage()
+		return fmt.Errorf("missing subcommand")
+	}
+
+	cli, err := client.New(*socket)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	ctx := context.Background()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	switch args[0] {
+	case "mode":
+		return runMode(ctx, cli, args[1:])
+	case "reload":
+		return runReload(ctx, cli)
+	case "plan":
+		return runPlan(ctx, cli, args[1:])
+	default:
+		fs.Usage()
+		return fmt.Errorf("unknown subcommand %q", args[0])
+	}
+}
+
+func runMode(ctx context.Context, cli *client.Client, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("mode requires a subcommand (get|set)")
+	}
+	switch args[0] {
+	case "get":
+		status, err := cli.Mode(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Active mode: %s\n", status.Active)
+		if len(status.Available) > 0 {
+			fmt.Printf("Available modes: %s\n", strings.Join(status.Available, ", "))
+		}
+		return nil
+	case "set":
+		if len(args) < 2 {
+			return fmt.Errorf("mode set requires a mode name")
+		}
+		if err := cli.SetMode(ctx, args[1]); err != nil {
+			return err
+		}
+		fmt.Printf("Switched to mode %s\n", args[1])
+		return nil
+	default:
+		return fmt.Errorf("unknown mode subcommand %q", args[0])
+	}
+}
+
+func runReload(ctx context.Context, cli *client.Client) error {
+	if err := cli.Reload(ctx); err != nil {
+		return err
+	}
+	fmt.Println("Reload requested")
+	return nil
+}
+
+func runPlan(ctx context.Context, cli *client.Client, args []string) error {
+	fs := flag.NewFlagSet("plan", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	explain := fs.Bool("explain", false, "include rule explanations in the response")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	result, err := cli.Plan(ctx, *explain)
+	if err != nil {
+		return err
+	}
+	if len(result.Commands) == 0 {
+		fmt.Println("No pending actions")
+		return nil
+	}
+	for _, cmd := range result.Commands {
+		fmt.Printf("dispatch: %s\n", strings.Join(cmd.Dispatch, " "))
+		if cmd.Reason != "" {
+			fmt.Printf("  reason: %s\n", cmd.Reason)
+		}
+	}
+	return nil
+}

--- a/hypr-smartd/internal/control/client/client.go
+++ b/hypr-smartd/internal/control/client/client.go
@@ -1,0 +1,150 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// defaultTimeout is used when the caller does not provide a context deadline.
+	defaultTimeout = 3 * time.Second
+	// socketFileName is the filename of the control socket within the runtime dir.
+	socketFileName = "control.sock"
+)
+
+// Client talks to the running hyprpal daemon over its control socket.
+type Client struct {
+	socketPath string
+}
+
+// ModeStatus describes the daemon's active mode and the available set.
+type ModeStatus struct {
+	Active    string   `json:"active"`
+	Available []string `json:"available"`
+}
+
+// PlanCommand represents a single hyprctl dispatch planned by the daemon.
+type PlanCommand struct {
+	Dispatch []string `json:"dispatch"`
+	Reason   string   `json:"reason,omitempty"`
+}
+
+// PlanResult captures the commands returned by the daemon when planning.
+type PlanResult struct {
+	Commands []PlanCommand `json:"commands"`
+}
+
+// New creates a client that connects to the provided socket path. When path is
+// empty, the default runtime path is used.
+func New(path string) (*Client, error) {
+	if path == "" {
+		var err error
+		path, err = DefaultSocketPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Client{socketPath: path}, nil
+}
+
+// DefaultSocketPath returns the expected location of the hyprpal control socket.
+func DefaultSocketPath() (string, error) {
+	if env := os.Getenv("HYPRPAL_CONTROL_SOCKET"); env != "" {
+		return env, nil
+	}
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" {
+		return "", errors.New("XDG_RUNTIME_DIR not set")
+	}
+	return filepath.Join(runtimeDir, "hyprpal", socketFileName), nil
+}
+
+// Mode retrieves the daemon's active mode along with the list of available modes.
+func (c *Client) Mode(ctx context.Context) (ModeStatus, error) {
+	var status ModeStatus
+	if err := c.do(ctx, request{Action: "mode.get"}, &status); err != nil {
+		return ModeStatus{}, err
+	}
+	return status, nil
+}
+
+// SetMode instructs the daemon to switch to the provided mode name.
+func (c *Client) SetMode(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("mode name cannot be empty")
+	}
+	payload := request{Action: "mode.set", Params: map[string]any{"name": name}}
+	return c.do(ctx, payload, nil)
+}
+
+// Reload asks the daemon to reload its configuration.
+func (c *Client) Reload(ctx context.Context) error {
+	return c.do(ctx, request{Action: "reload"}, nil)
+}
+
+// Plan requests the daemon to compute and optionally explain the next plan.
+func (c *Client) Plan(ctx context.Context, explain bool) (PlanResult, error) {
+	params := map[string]any{"explain": explain}
+	var result PlanResult
+	if err := c.do(ctx, request{Action: "plan", Params: params}, &result); err != nil {
+		return PlanResult{}, err
+	}
+	return result, nil
+}
+
+type request struct {
+	Action string         `json:"action"`
+	Params map[string]any `json:"params,omitempty"`
+}
+
+type response struct {
+	Status string          `json:"status"`
+	Error  string          `json:"error,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+func (c *Client) do(ctx context.Context, req request, out any) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", c.socketPath)
+	if err != nil {
+		return fmt.Errorf("dial control socket: %w", err)
+	}
+	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		return fmt.Errorf("encode request: %w", err)
+	}
+	var resp response
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if resp.Status != "ok" {
+		if resp.Error == "" {
+			resp.Error = "unknown control error"
+		}
+		return errors.New(resp.Error)
+	}
+	if out == nil || resp.Data == nil {
+		return nil
+	}
+	if err := json.Unmarshal(resp.Data, out); err != nil {
+		return fmt.Errorf("decode payload: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a new hsctl command-line entrypoint with subcommands for mode, reload, and plan inspection
- introduce an internal control client to talk to the daemon over the Unix socket
- update build tooling so hsctl is built and installed alongside hyprpal

## Acceptance Criteria
- [x] Create a new `cmd/hsctl/main.go` entry point that supports the requested subcommands
- [x] Ensure the CLI communicates with the daemon via the Unix-domain control socket
- [x] Update the Makefile so `make build` produces both `hyprpal` and `hsctl`

## How to test
- `cd hypr-smartd && go test ./...`
- `cd hypr-smartd && make build`

## Screenshots
- N/A (CLI tooling change)


------
https://chatgpt.com/codex/tasks/task_e_68e12320bd6c8325a7e44519081c43d7