### PR TITLE
feat: add control server and plan preview

### DIFF
--- a/hypr-smartd/internal/control/client/client.go
+++ b/hypr-smartd/internal/control/client/client.go
@@ -6,16 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"time"
+
+	"github.com/hyprpal/hyprpal/internal/control"
 )
 
 const (
 	// defaultTimeout is used when the caller does not provide a context deadline.
 	defaultTimeout = 3 * time.Second
-	// socketFileName is the filename of the control socket within the runtime dir.
-	socketFileName = "control.sock"
 )
 
 // Client talks to the running hyprpal daemon over its control socket.
@@ -23,29 +21,21 @@ type Client struct {
 	socketPath string
 }
 
-// ModeStatus describes the daemon's active mode and the available set.
-type ModeStatus struct {
-	Active    string   `json:"active"`
-	Available []string `json:"available"`
-}
-
-// PlanCommand represents a single hyprctl dispatch planned by the daemon.
-type PlanCommand struct {
-	Dispatch []string `json:"dispatch"`
-	Reason   string   `json:"reason,omitempty"`
-}
-
-// PlanResult captures the commands returned by the daemon when planning.
-type PlanResult struct {
-	Commands []PlanCommand `json:"commands"`
-}
+type (
+	// ModeStatus describes the daemon's active mode and the available set.
+	ModeStatus = control.ModeStatus
+	// PlanCommand represents a single hyprctl dispatch planned by the daemon.
+	PlanCommand = control.PlanCommand
+	// PlanResult captures the commands returned by the daemon when planning.
+	PlanResult = control.PlanResult
+)
 
 // New creates a client that connects to the provided socket path. When path is
 // empty, the default runtime path is used.
 func New(path string) (*Client, error) {
 	if path == "" {
 		var err error
-		path, err = DefaultSocketPath()
+		path, err = control.DefaultSocketPath()
 		if err != nil {
 			return nil, err
 		}
@@ -53,22 +43,10 @@ func New(path string) (*Client, error) {
 	return &Client{socketPath: path}, nil
 }
 
-// DefaultSocketPath returns the expected location of the hyprpal control socket.
-func DefaultSocketPath() (string, error) {
-	if env := os.Getenv("HYPRPAL_CONTROL_SOCKET"); env != "" {
-		return env, nil
-	}
-	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	if runtimeDir == "" {
-		return "", errors.New("XDG_RUNTIME_DIR not set")
-	}
-	return filepath.Join(runtimeDir, "hyprpal", socketFileName), nil
-}
-
 // Mode retrieves the daemon's active mode along with the list of available modes.
 func (c *Client) Mode(ctx context.Context) (ModeStatus, error) {
 	var status ModeStatus
-	if err := c.do(ctx, request{Action: "mode.get"}, &status); err != nil {
+	if err := c.do(ctx, control.Request{Action: control.ActionModeGet}, &status); err != nil {
 		return ModeStatus{}, err
 	}
 	return status, nil
@@ -79,37 +57,26 @@ func (c *Client) SetMode(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("mode name cannot be empty")
 	}
-	payload := request{Action: "mode.set", Params: map[string]any{"name": name}}
+	payload := control.Request{Action: control.ActionModeSet, Params: map[string]any{"name": name}}
 	return c.do(ctx, payload, nil)
 }
 
 // Reload asks the daemon to reload its configuration.
 func (c *Client) Reload(ctx context.Context) error {
-	return c.do(ctx, request{Action: "reload"}, nil)
+	return c.do(ctx, control.Request{Action: control.ActionReload}, nil)
 }
 
 // Plan requests the daemon to compute and optionally explain the next plan.
 func (c *Client) Plan(ctx context.Context, explain bool) (PlanResult, error) {
 	params := map[string]any{"explain": explain}
 	var result PlanResult
-	if err := c.do(ctx, request{Action: "plan", Params: params}, &result); err != nil {
+	if err := c.do(ctx, control.Request{Action: control.ActionPlan, Params: params}, &result); err != nil {
 		return PlanResult{}, err
 	}
 	return result, nil
 }
 
-type request struct {
-	Action string         `json:"action"`
-	Params map[string]any `json:"params,omitempty"`
-}
-
-type response struct {
-	Status string          `json:"status"`
-	Error  string          `json:"error,omitempty"`
-	Data   json.RawMessage `json:"data,omitempty"`
-}
-
-func (c *Client) do(ctx context.Context, req request, out any) error {
+func (c *Client) do(ctx context.Context, req control.Request, out any) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -130,11 +97,11 @@ func (c *Client) do(ctx context.Context, req request, out any) error {
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		return fmt.Errorf("encode request: %w", err)
 	}
-	var resp response
+	var resp control.Response
 	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
 		return fmt.Errorf("decode response: %w", err)
 	}
-	if resp.Status != "ok" {
+	if resp.Status != control.StatusOK {
 		if resp.Error == "" {
 			resp.Error = "unknown control error"
 		}
@@ -143,7 +110,11 @@ func (c *Client) do(ctx context.Context, req request, out any) error {
 	if out == nil || resp.Data == nil {
 		return nil
 	}
-	if err := json.Unmarshal(resp.Data, out); err != nil {
+	data, err := json.Marshal(resp.Data)
+	if err != nil {
+		return fmt.Errorf("encode payload: %w", err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
 		return fmt.Errorf("decode payload: %w", err)
 	}
 	return nil

--- a/hypr-smartd/internal/control/server.go
+++ b/hypr-smartd/internal/control/server.go
@@ -1,0 +1,216 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/hyprpal/hyprpal/internal/engine"
+	"github.com/hyprpal/hyprpal/internal/util"
+)
+
+// Server hosts the hyprpal control socket and serves requests.
+type Server struct {
+	engine     *engine.Engine
+	logger     *util.Logger
+	reload     func(reason string) error
+	socketPath string
+
+	mu       sync.Mutex
+	listener net.Listener
+}
+
+// NewServer creates a new control server.
+func NewServer(eng *engine.Engine, logger *util.Logger, reload func(reason string) error) (*Server, error) {
+	path, err := DefaultSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		engine:     eng,
+		logger:     logger,
+		reload:     reload,
+		socketPath: path,
+	}, nil
+}
+
+// Serve listens on the control socket until the context is cancelled.
+func (s *Server) Serve(ctx context.Context) error {
+	if err := s.prepareSocket(); err != nil {
+		return err
+	}
+	s.logger.Infof("control server listening on %s", s.socketPath)
+	defer s.cleanup()
+
+	go func() {
+		<-ctx.Done()
+		s.mu.Lock()
+		if s.listener != nil {
+			s.listener.Close()
+		}
+		s.mu.Unlock()
+	}()
+
+	for {
+		conn, err := s.accept(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			s.logger.Errorf("control accept error: %v", err)
+			continue
+		}
+		go s.handle(ctx, conn)
+	}
+}
+
+func (s *Server) accept(ctx context.Context) (net.Conn, error) {
+	s.mu.Lock()
+	listener := s.listener
+	s.mu.Unlock()
+	if listener == nil {
+		return nil, context.Canceled
+	}
+	conn, err := listener.Accept()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (s *Server) prepareSocket() error {
+	dir := filepath.Dir(s.socketPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create control dir: %w", err)
+	}
+	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale socket: %w", err)
+	}
+	listener, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return fmt.Errorf("listen on control socket: %w", err)
+	}
+	if err := os.Chmod(s.socketPath, 0o600); err != nil {
+		listener.Close()
+		return fmt.Errorf("chmod control socket: %w", err)
+	}
+	s.mu.Lock()
+	s.listener = listener
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Server) cleanup() {
+	s.mu.Lock()
+	listener := s.listener
+	s.listener = nil
+	s.mu.Unlock()
+	if listener != nil {
+		listener.Close()
+	}
+	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.logger.Warnf("remove control socket: %v", err)
+	}
+}
+
+func (s *Server) handle(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	dec := json.NewDecoder(conn)
+	var req Request
+	if err := dec.Decode(&req); err != nil {
+		s.writeError(conn, fmt.Errorf("decode request: %w", err))
+		return
+	}
+	switch req.Action {
+	case ActionModeGet:
+		s.handleModeGet(conn)
+	case ActionModeSet:
+		s.handleModeSet(conn, req.Params)
+	case ActionReload:
+		s.handleReload(conn)
+	case ActionPlan:
+		s.handlePlan(ctx, conn, req.Params)
+	default:
+		s.writeError(conn, fmt.Errorf("unknown action %q", req.Action))
+	}
+}
+
+func (s *Server) handleModeGet(conn net.Conn) {
+	status := ModeStatus{
+		Active:    s.engine.ActiveMode(),
+		Available: s.engine.AvailableModes(),
+	}
+	s.writeOK(conn, status)
+}
+
+func (s *Server) handleModeSet(conn net.Conn, params map[string]any) {
+	name, _ := params["name"].(string)
+	if name == "" {
+		s.writeError(conn, errors.New("missing mode name"))
+		return
+	}
+	if err := s.engine.SetMode(name); err != nil {
+		s.writeError(conn, err)
+		return
+	}
+	s.writeOK(conn, nil)
+}
+
+func (s *Server) handleReload(conn net.Conn) {
+	if s.reload == nil {
+		s.writeError(conn, errors.New("reload not supported"))
+		return
+	}
+	if err := s.reload("control request"); err != nil {
+		s.writeError(conn, err)
+		return
+	}
+	s.writeOK(conn, nil)
+}
+
+func (s *Server) handlePlan(ctx context.Context, conn net.Conn, params map[string]any) {
+	explain, _ := params["explain"].(bool)
+	commands, err := s.engine.PreviewPlan(ctx, explain)
+	if err != nil {
+		s.writeError(conn, err)
+		return
+	}
+	result := PlanResult{Commands: make([]PlanCommand, 0, len(commands))}
+	for _, cmd := range commands {
+		result.Commands = append(result.Commands, PlanCommand{
+			Dispatch: cmd.Dispatch,
+			Reason:   cmd.Reason,
+		})
+	}
+	s.writeOK(conn, result)
+}
+
+func (s *Server) writeOK(conn net.Conn, data any) {
+	resp := Response{Status: StatusOK}
+	if data != nil {
+		resp.Data = data
+	}
+	_ = json.NewEncoder(conn).Encode(resp)
+}
+
+func (s *Server) writeError(conn net.Conn, err error) {
+	resp := Response{Status: StatusError}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	_ = json.NewEncoder(conn).Encode(resp)
+}

--- a/hypr-smartd/internal/control/types.go
+++ b/hypr-smartd/internal/control/types.go
@@ -1,0 +1,68 @@
+package control
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// SocketFileName is the filename of the control socket within the runtime dir.
+	SocketFileName = "control.sock"
+
+	// Action names supported by the control protocol.
+	ActionModeGet = "mode.get"
+	ActionModeSet = "mode.set"
+	ActionReload  = "reload"
+	ActionPlan    = "plan"
+
+	// Response statuses.
+	StatusOK    = "ok"
+	StatusError = "error"
+)
+
+// Request represents a control API request.
+type Request struct {
+	Action string         `json:"action"`
+	Params map[string]any `json:"params,omitempty"`
+}
+
+// Response represents a control API response.
+type Response struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+	Data   any    `json:"data,omitempty"`
+}
+
+// ModeStatus describes the daemon's active mode and the available set.
+type ModeStatus struct {
+	Active    string   `json:"active"`
+	Available []string `json:"available"`
+}
+
+// PlanCommand represents a single hyprctl dispatch planned by the daemon.
+type PlanCommand struct {
+	Dispatch []string `json:"dispatch"`
+	Reason   string   `json:"reason,omitempty"`
+}
+
+// PlanResult captures the commands returned by the daemon when planning.
+type PlanResult struct {
+	Commands []PlanCommand `json:"commands"`
+}
+
+// DefaultSocketPath returns the expected location of the hyprpal control socket.
+func DefaultSocketPath() (string, error) {
+	if env := os.Getenv("HYPRPAL_CONTROL_SOCKET"); env != "" {
+		return env, nil
+	}
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	base := runtimeDir
+	if base == "" {
+		base = os.TempDir()
+		if base == "" {
+			return "", errors.New("no runtime directory available")
+		}
+	}
+	return filepath.Join(base, "hyprpal", SocketFileName), nil
+}


### PR DESCRIPTION
## Summary
- add a unix-socket control server and shared protocol types for hyprpal
- extend the engine with concurrency-safe accessors and plan preview support
- wire the control server into the daemon and reuse the existing reload path

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e12a4206008325bccbc03cf2a85e8e