### PR TITLE
feat: add socket-backed dispatcher with batching

### DIFF
--- a/cmd/hyprpal/main.go
+++ b/cmd/hyprpal/main.go
@@ -63,7 +63,8 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hypr := ipc.NewClient()
+	hypr, strategy := ipc.NewEngineClient(logger)
+	logger.Infof("using %s dispatch strategy", strategy)
 	eng := engine.New(hypr, logger, modes, *dryRun)
 	if *startMode != "" {
 		if err := eng.SetMode(*startMode); err != nil {

--- a/internal/ipc/socket.go
+++ b/internal/ipc/socket.go
@@ -1,0 +1,76 @@
+package ipc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hyprpal/hyprpal/internal/layout"
+)
+
+type socketDispatcher struct {
+	path string
+}
+
+func newSocketDispatcher() (*socketDispatcher, error) {
+	path, err := dispatchSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	return &socketDispatcher{path: path}, nil
+}
+
+func (d *socketDispatcher) Dispatch(args ...string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return d.DispatchBatch([][]string{args})
+}
+
+func (d *socketDispatcher) DispatchBatch(commands [][]string) error {
+	if len(commands) == 0 {
+		return nil
+	}
+	conn, err := net.Dial("unix", d.path)
+	if err != nil {
+		return fmt.Errorf("connect dispatch socket: %w", err)
+	}
+	defer conn.Close()
+
+	lines := make([]string, 0, len(commands))
+	for _, cmd := range commands {
+		if len(cmd) == 0 {
+			continue
+		}
+		parts := append([]string{"dispatch"}, cmd...)
+		lines = append(lines, strings.Join(parts, " "))
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	payload := strings.Join(lines, "\n") + "\n"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		return fmt.Errorf("write dispatch payload: %w", err)
+	}
+	return nil
+}
+
+func (d *socketDispatcher) DispatchSocketPath() string {
+	return d.path
+}
+
+func dispatchSocketPath() (string, error) {
+	sig := os.Getenv("HYPRLAND_INSTANCE_SIGNATURE")
+	if sig == "" {
+		return "", fmt.Errorf("HYPRLAND_INSTANCE_SIGNATURE not set")
+	}
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" {
+		return "", fmt.Errorf("XDG_RUNTIME_DIR not set")
+	}
+	return filepath.Join(runtimeDir, "hypr", sig, ".socket.sock"), nil
+}
+
+var _ layout.BatchDispatcher = (*socketDispatcher)(nil)

--- a/internal/ipc/socket_test.go
+++ b/internal/ipc/socket_test.go
@@ -1,0 +1,117 @@
+package ipc
+
+import (
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSocketDispatcherDispatchBatch(t *testing.T) {
+	runtimeDir := t.TempDir()
+	sig := "instance"
+	setEnv(t, "XDG_RUNTIME_DIR", runtimeDir)
+	setEnv(t, "HYPRLAND_INSTANCE_SIGNATURE", sig)
+
+	socketPath := filepath.Join(runtimeDir, "hypr", sig, ".socket.sock")
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	disp, err := newSocketDispatcher()
+	if err != nil {
+		t.Fatalf("newSocketDispatcher: %v", err)
+	}
+	if got := disp.DispatchSocketPath(); got != socketPath {
+		t.Fatalf("unexpected socket path: got %q want %q", got, socketPath)
+	}
+
+	batchConn := make(chan net.Conn, 1)
+	batchErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			batchErr <- err
+			return
+		}
+		batchConn <- conn
+	}()
+
+	commands := [][]string{{"focuswindow", "address:test"}, {"movewindowpixel", "exact", "0", "0"}}
+	if err := disp.DispatchBatch(commands); err != nil {
+		t.Fatalf("DispatchBatch: %v", err)
+	}
+
+	var conn net.Conn
+	select {
+	case err := <-batchErr:
+		t.Fatalf("batch accept: %v", err)
+	case conn = <-batchConn:
+	}
+	data, err := io.ReadAll(conn)
+	conn.Close()
+	if err != nil {
+		t.Fatalf("read batch payload: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	expected := []string{
+		"dispatch focuswindow address:test",
+		"dispatch movewindowpixel exact 0 0",
+	}
+	if !reflect.DeepEqual(lines, expected) {
+		t.Fatalf("unexpected payload: %#v", lines)
+	}
+
+	singleConn := make(chan net.Conn, 1)
+	singleErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			singleErr <- err
+			return
+		}
+		singleConn <- conn
+	}()
+
+	if err := disp.Dispatch("focuswindow", "address:solo"); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	var singleConnVal net.Conn
+	select {
+	case err := <-singleErr:
+		t.Fatalf("single accept: %v", err)
+	case singleConnVal = <-singleConn:
+	}
+	singleData, err := io.ReadAll(singleConnVal)
+	singleConnVal.Close()
+	if err != nil {
+		t.Fatalf("read single payload: %v", err)
+	}
+	single := strings.TrimSpace(string(singleData))
+	if single != "dispatch focuswindow address:solo" {
+		t.Fatalf("unexpected single payload: %q", single)
+	}
+}
+
+func setEnv(t *testing.T, key, value string) {
+	t.Helper()
+	original, had := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("setenv %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if !had {
+			os.Unsetenv(key)
+			return
+		}
+		os.Setenv(key, original)
+	})
+}


### PR DESCRIPTION
## Summary
- implement a unix socket dispatcher and batching support for layout plans
- extend the engine IPC factory to prefer the socket strategy with hyprctl fallback
- add unit tests for both dispatch strategies and the new socket client

## Acceptance Criteria
- [x] Socket dispatcher writes to the expected Hyprland command socket
- [x] Engine can fall back to hyprctl shell-out dispatching
- [x] Tests cover both dispatch strategies

## How to Test
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e136261750832584381a7d0c5ef4cb