### PR TITLE
Add managed workspace guards to intrusive actions

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,4 +1,7 @@
 # Launch hyprpal with `--dispatch=socket|hyprctl` to match your environment.
+managedWorkspaces:
+  - 3
+  - 4
 modes:
   - name: Coding
     rules:
@@ -21,6 +24,7 @@ modes:
       - name: Fullscreen active game
         when:
           mode: Gaming
+        allowUnmanaged: true
         actions:
           - type: layout.fullscreen
             params:

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -272,9 +272,11 @@ func (e *Engine) evaluate(world *state.World, now time.Time, log bool) (layout.P
 		rulePlan := layout.Plan{}
 		for _, action := range rule.Actions {
 			p, err := action.Plan(rules.ActionContext{
-				World:    world,
-				Logger:   e.logger,
-				RuleName: rule.Name,
+				World:             world,
+				Logger:            e.logger,
+				RuleName:          rule.Name,
+				ManagedWorkspaces: rule.ManagedWorkspaces,
+				AllowUnmanaged:    rule.AllowUnmanaged,
 			})
 			if err != nil {
 				e.logger.Errorf("rule %s action error: %v", rule.Name, err)

--- a/internal/rules/actions_test.go
+++ b/internal/rules/actions_test.go
@@ -82,3 +82,115 @@ func TestSidecarDockPlanIdempotentLogs(t *testing.T) {
 		t.Fatalf("expected idempotent skip log, got %q", buf.String())
 	}
 }
+
+func TestSidecarDockPlanSkipsOnUnmanagedWorkspace(t *testing.T) {
+	action := &SidecarDockAction{
+		WorkspaceID:  5,
+		Side:         "right",
+		WidthPercent: 25,
+		Match:        func(state.Client) bool { return true },
+	}
+
+	world := &state.World{
+		Clients: []state.Client{{
+			Address:     "0xabc",
+			WorkspaceID: 5,
+			MonitorName: "DP-1",
+			Geometry:    layout.Rect{X: 0, Y: 0, Width: 800, Height: 600},
+		}},
+		Workspaces: []state.Workspace{{ID: 5, MonitorName: "DP-1"}},
+		Monitors: []state.Monitor{{
+			Name:      "DP-1",
+			Rectangle: layout.Rect{X: 0, Y: 0, Width: 1600, Height: 900},
+		}},
+	}
+
+	buf := &bytes.Buffer{}
+	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
+	ctx := ActionContext{
+		World:             world,
+		Logger:            logger,
+		RuleName:          "sidecar",
+		ManagedWorkspaces: map[int]struct{}{1: {}},
+	}
+
+	plan, err := action.Plan(ctx)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	if len(plan.Commands) != 0 {
+		t.Fatalf("expected no commands when workspace unmanaged, got %d", len(plan.Commands))
+	}
+	if !strings.Contains(buf.String(), "workspace 5 unmanaged") {
+		t.Fatalf("expected unmanaged workspace log, got %q", buf.String())
+	}
+}
+
+func TestFullscreenPlanSkipsOnUnmanagedWorkspace(t *testing.T) {
+	action := &FullscreenAction{Target: "active", Match: func(state.Client) bool { return true }}
+	world := &state.World{
+		Clients: []state.Client{{
+			Address:        "0xabc",
+			WorkspaceID:    7,
+			MonitorName:    "DP-1",
+			FullscreenMode: 0,
+			Focused:        true,
+		}},
+		Workspaces:          []state.Workspace{{ID: 7, MonitorName: "DP-1"}},
+		Monitors:            []state.Monitor{{Name: "DP-1", Rectangle: layout.Rect{Width: 1600, Height: 900}}},
+		ActiveClientAddress: "0xabc",
+	}
+	buf := &bytes.Buffer{}
+	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
+	ctx := ActionContext{
+		World:             world,
+		Logger:            logger,
+		RuleName:          "fullscreen",
+		ManagedWorkspaces: map[int]struct{}{1: {}},
+	}
+
+	plan, err := action.Plan(ctx)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	if len(plan.Commands) != 0 {
+		t.Fatalf("expected no commands when workspace unmanaged, got %d", len(plan.Commands))
+	}
+	if !strings.Contains(buf.String(), "workspace 7 unmanaged") {
+		t.Fatalf("expected unmanaged workspace log, got %q", buf.String())
+	}
+}
+
+func TestFullscreenPlanAllowsWhenOptedIn(t *testing.T) {
+	action := &FullscreenAction{Target: "active", Match: func(state.Client) bool { return true }}
+	world := &state.World{
+		Clients: []state.Client{{
+			Address:     "0xabc",
+			WorkspaceID: 7,
+			MonitorName: "DP-1",
+		}},
+		Workspaces:          []state.Workspace{{ID: 7, MonitorName: "DP-1"}},
+		Monitors:            []state.Monitor{{Name: "DP-1", Rectangle: layout.Rect{Width: 1600, Height: 900}}},
+		ActiveClientAddress: "0xabc",
+	}
+	buf := &bytes.Buffer{}
+	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
+	ctx := ActionContext{
+		World:             world,
+		Logger:            logger,
+		RuleName:          "fullscreen",
+		ManagedWorkspaces: map[int]struct{}{1: {}},
+		AllowUnmanaged:    true,
+	}
+
+	plan, err := action.Plan(ctx)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	if len(plan.Commands) == 0 {
+		t.Fatalf("expected commands when unmanaged workspaces allowed")
+	}
+	if strings.Contains(buf.String(), "unmanaged") {
+		t.Fatalf("unexpected unmanaged log when allowUnmanaged is true: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add managed workspace lists and rule-level unmanaged opt-in to the config and builder
- ensure intrusive actions skip unmanaged workspaces unless explicitly allowed, logging the skip reason
- expand action tests to cover unmanaged suppression and opt-in behavior

## Acceptance Criteria
- [x] Config supports declaring managed workspaces and per-rule unmanaged opt-in
- [x] Intrusive action plans are skipped on unmanaged workspaces unless explicitly opted in, with informative logs
- [x] Unit tests cover managed workspace enforcement for actions

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e16741ba248325a016adf573f7d86d