### PR TITLE
docs: document guardrails and workspace allow list

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,5 +1,6 @@
 # Launch hyprpal with `--dispatch=socket|hyprctl` to match your environment.
 managedWorkspaces:
+  # hyprpal will only touch workspaces listed here unless a rule opts out.
   - 3
   - 4
 modes:
@@ -19,12 +20,27 @@ modes:
               widthPercent: 25 # allowed range: 10-50
               match:
                 anyClass: [Slack, discord]
+      - name: Float design review on workspace 7
+        when:
+          all:
+            - mode: Coding
+            - workspace.id: 7
+            - app.class: Figma
+        allowUnmanaged: true # opt this rule into unmanaged workspace 7
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 7
+              side: left
+              widthPercent: 30
+              match:
+                class: Figma
   - name: Gaming
     rules:
       - name: Fullscreen active game
         when:
           mode: Gaming
-        allowUnmanaged: true
+        allowUnmanaged: true # let fullscreen apply on any workspace
         actions:
           - type: layout.fullscreen
             params:


### PR DESCRIPTION
## Summary
- expand the sample configuration with managed workspace comments and an unmanaged override example
- document managed workspace allow-listing, per-rule overrides, and loop protection guardrails in the README
- call out runtime flags testers can use to observe the guardrails while iterating

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e168da326883258b87863a1ab6fadf