### PR TITLE
Add trace log level support

### DIFF
--- a/cmd/hyprpal/main.go
+++ b/cmd/hyprpal/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	cfgPath := flag.String("config", defaultConfig, "path to YAML config")
 	dryRun := flag.Bool("dry-run", false, "do not dispatch commands")
-	logLevel := flag.String("log-level", "info", "log level (debug|info|warn|error)")
+	logLevel := flag.String("log-level", "info", "log level (trace|debug|info|warn|error)")
 	startMode := flag.String("mode", "", "initial mode to activate")
 	dispatchStrategy := flag.String("dispatch", string(ipc.DispatchStrategySocket), "dispatch strategy (socket|hyprctl)")
 	flag.Parse()

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -12,13 +12,15 @@ import (
 type LogLevel int32
 
 const (
-	LevelDebug LogLevel = iota
+	LevelTrace LogLevel = iota
+	LevelDebug
 	LevelInfo
 	LevelWarn
 	LevelError
 )
 
 var levelNames = map[string]LogLevel{
+	"trace": LevelTrace,
 	"debug": LevelDebug,
 	"info":  LevelInfo,
 	"warn":  LevelWarn,
@@ -58,6 +60,9 @@ func (l *Logger) logf(level LogLevel, prefix string, format string, args ...inte
 	l.base.Printf("[%s] %s", strings.ToUpper(prefix), fmt.Sprintf(format, args...))
 }
 
+func (l *Logger) Tracef(format string, args ...interface{}) {
+	l.logf(LevelTrace, "trace", format, args...)
+}
 func (l *Logger) Debugf(format string, args ...interface{}) {
 	l.logf(LevelDebug, "debug", format, args...)
 }

--- a/internal/util/log_test.go
+++ b/internal/util/log_test.go
@@ -1,0 +1,24 @@
+package util
+
+import "testing"
+
+func TestParseLogLevel(t *testing.T) {
+	tests := map[string]LogLevel{
+		"trace": LevelTrace,
+		"TRACE": LevelTrace,
+		"debug": LevelDebug,
+		"info":  LevelInfo,
+		"warn":  LevelWarn,
+		"error": LevelError,
+	}
+
+	for input, want := range tests {
+		if got := ParseLogLevel(input); got != want {
+			t.Fatalf("ParseLogLevel(%q) = %v, want %v", input, got, want)
+		}
+	}
+
+	if got := ParseLogLevel("unknown"); got != LevelInfo {
+		t.Fatalf("ParseLogLevel default = %v, want %v", got, LevelInfo)
+	}
+}


### PR DESCRIPTION
## Summary
- add a trace log level and helper so verbose logs can be emitted explicitly
- advertise the trace level on the CLI flag and ensure parsing includes it
- cover ParseLogLevel with unit tests including the new option

## Acceptance Criteria
- [x] Logging supports configuring the trace level
- [x] CLI help documents all supported log levels
- [x] ParseLogLevel handles the new trace value

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e16aab83048325961e992d5c92b832